### PR TITLE
fix(winet): prevent nil-pointer panic on service restart

### DIFF
--- a/internal/pkg/winet/poller.go
+++ b/internal/pkg/winet/poller.go
@@ -32,10 +32,11 @@ func (s *service) runPollLoop(ctx context.Context) {
 	s.logger.Debug("poll loop started")
 
 	for {
-		if s.conn == nil {
+		conn := s.getConn()
+		if conn == nil {
 			return
 		}
-		s.sendDeviceListRequest(ctx, s.conn)
+		s.sendDeviceListRequest(ctx, conn)
 
 		v, err := s.pending.wait(ctx)
 		if err != nil {
@@ -86,7 +87,7 @@ func (s *service) queryDevices(ctx context.Context, devices []model.DeviceListOb
 		s.logger.Debug("polling device", zap.String("sn", dev.SerialNumber))
 
 		for _, qs := range model.DeviceStages[device.DevType] {
-			if s.conn == nil {
+			if s.getConn() == nil {
 				return
 			}
 			if err := s.sendQueryRequest(qs, device.DeviceID); err != nil {
@@ -118,6 +119,10 @@ func (s *service) sendQueryRequest(qs model.QueryStage, deviceID int) error {
 	if err != nil {
 		return err
 	}
+	conn := s.getConn()
+	if conn == nil {
+		return fmt.Errorf("connection is nil, cannot send query")
+	}
 	s.logger.Debug("sending query", zap.String("stage", qs.String()))
-	return s.conn.Send(ws.Msg{Body: data})
+	return conn.Send(ws.Msg{Body: data})
 }

--- a/internal/pkg/winet/winet.go
+++ b/internal/pkg/winet/winet.go
@@ -71,6 +71,7 @@ func (p *pendingCmd) deliver(v any) {
 type service struct {
 	cfg        *config.WinetConfig
 	properties map[string]string
+	connMu     sync.RWMutex // protects conn
 	conn       ws.Connection
 	events     chan SessionEvent
 	token      string
@@ -104,6 +105,16 @@ func New(cfg *config.WinetConfig, pub publisher.DataPublisher) *service {
 		storedData: []byte{},
 		events:     make(chan SessionEvent, 1),
 	}
+}
+
+// getConn returns a snapshot of the current connection under a read lock.
+// All callers that need to use s.conn should go through this method so that
+// concurrent writes from reconnect() cannot produce a nil-pointer dereference.
+func (s *service) getConn() ws.Connection {
+	s.connMu.RLock()
+	c := s.conn
+	s.connMu.RUnlock()
+	return c
 }
 
 // Events returns the channel on which session lifecycle events are delivered.
@@ -179,13 +190,15 @@ func (s *service) onMessage(data []byte, c ws.Connection) {
 
 	s.logger.Debug("received message", zap.String("result", result.ResultMessage), zap.String("query_stage", result.ResultData.Service.String()))
 	if result.ResultMessage == "login timeout" {
-		s.logger.Debug("login timeout, reconnecting")
+		s.logger.Debug("login timeout, signalling reconnect")
+		// Signal the reconnect via the events channel only. startWinetService will
+		// call Connect(), which cancels the poll loop before calling reconnect().
+		// Calling reconnect() here directly raced with the poll-loop goroutine
+		// reading s.conn and was the root cause of the nil-pointer panic on restart.
 		select {
 		case s.events <- SessionEvent{Err: ErrTimeout}:
 		default:
 		}
-		err := s.reconnect(context.Background())
-		s.onError(err)
 		return
 	}
 
@@ -230,12 +243,16 @@ func (s *service) reconnect(ctx context.Context) error {
 	// Close the old connection before creating a new one. Without this, the old
 	// connection's readLoop and setupPing goroutines keep running and continue
 	// calling onMessage/onError on this service, racing with the new session.
+	// Hold the write lock so getConn() callers on the poll loop goroutine see a
+	// consistent nil (not a half-closed connection) during the transition.
+	s.connMu.Lock()
 	if s.conn != nil {
 		if err := s.conn.Close(); err != nil {
 			s.logger.Warn("error closing previous connection", zap.Error(err))
 		}
 		s.conn = nil
 	}
+	s.connMu.Unlock()
 
 	var u url.URL
 	if s.cfg.Ssl {
@@ -248,7 +265,7 @@ func (s *service) reconnect(ctx context.Context) error {
 
 	s.token = "" // clear it out just in case.
 
-	s.conn = ws.New(
+	newConn := ws.New(
 		ws.OnConnected(s.onconnect),
 		ws.OnMessage(s.onMessage),
 		ws.OnError(s.onError),
@@ -257,10 +274,18 @@ func (s *service) reconnect(ctx context.Context) error {
 		ws.WithPingMsg([]byte("ping")),
 	)
 
-	if err := s.conn.Dial(ctx, u.String(), ""); err != nil {
+	// Dial without holding the lock — I/O must not block readers.
+	// s.conn remains nil until the dial succeeds, so poll-loop callers that
+	// observe nil via getConn() will exit cleanly rather than panic.
+	if err := newConn.Dial(ctx, u.String(), ""); err != nil {
 		s.logger.Error("failed to connect to", zap.String("url", u.String()), zap.Error(err))
 		return err
 	}
+
+	s.connMu.Lock()
+	s.conn = newConn
+	s.connMu.Unlock()
+
 	s.logger.Debug("successfully connected to", zap.String("url", u.String()))
 	return nil
 }

--- a/internal/pkg/winet/winet_test.go
+++ b/internal/pkg/winet/winet_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -799,4 +800,99 @@ func TestSendIfErr_RoutesToEventsNeverErrChan(t *testing.T) {
 	case <-time.After(100 * time.Millisecond):
 		t.Fatal("sendIfErr must deliver to events channel — got nothing")
 	}
+}
+
+// --- nil-conn / restart race regression tests ---
+
+// TestSendQueryRequest_NilConn_ReturnsError is the primary regression test for the
+// restart nil-pointer panic. Before the fix, sendQueryRequest called s.conn.Send()
+// without a nil check; a concurrent reconnect() that set s.conn=nil would panic.
+// After the fix it must return a descriptive error instead.
+func TestSendQueryRequest_NilConn_ReturnsError(t *testing.T) {
+	svc := newTestService()
+	// conn is intentionally left nil — simulates the window during reconnect.
+
+	err := svc.sendQueryRequest(model.Real, 1)
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "connection is nil")
+}
+
+// TestSendQueryRequest_ConcurrentReconnect_DoesNotPanic reproduces the exact race that
+// caused the production nil-pointer panic: one goroutine calls sendQueryRequest while
+// another toggles s.conn between nil and a live mock (simulating reconnect()).
+// Run with -race to confirm no data races remain.
+func TestSendQueryRequest_ConcurrentReconnect_DoesNotPanic(t *testing.T) {
+	svc := newTestService()
+
+	conn := socketsmocks.NewConnection(t)
+	conn.Mock.On("Send", mock.Anything).Return(nil).Maybe()
+	conn.Mock.On("Close").Return(nil).Maybe()
+
+	svc.connMu.Lock()
+	svc.conn = conn
+	svc.connMu.Unlock()
+
+	const iterations = 500
+	var wg sync.WaitGroup
+
+	// Goroutine 1: continuously send queries — must never panic.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			_ = svc.sendQueryRequest(model.Real, 1)
+		}
+	}()
+
+	// Goroutine 2: simulate reconnect toggling conn nil → non-nil under the lock.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			svc.connMu.Lock()
+			svc.conn = nil
+			svc.connMu.Unlock()
+			svc.connMu.Lock()
+			svc.conn = conn
+			svc.connMu.Unlock()
+		}
+	}()
+
+	assert.NotPanics(t, func() { wg.Wait() })
+}
+
+// TestOnMessage_LoginTimeout_NoInBandReconnect verifies the other half of the fix:
+// a "login timeout" message must NOT call reconnect() in-band. Previously the
+// in-band reconnect() set s.conn=nil while the poll-loop goroutine was actively
+// reading it, causing the panic. Now only the events channel signal is sent and
+// the existing connection must remain untouched until startWinetService calls
+// Connect() with the poll loop properly cancelled.
+func TestOnMessage_LoginTimeout_NoInBandReconnect(t *testing.T) {
+	svc := New(&config.WinetConfig{Host: "127.0.0.1"}, noopPublisher{})
+	svc.ctx = context.Background()
+	svc.properties = map[string]string{}
+	svc.loginReady = make(chan struct{})
+
+	conn := socketsmocks.NewConnection(t)
+	// Close must NOT be called — the in-band reconnect() would have called it.
+	// testify/mock's AssertExpectations (via t.Cleanup) will fail if Close is called.
+	svc.conn = conn
+
+	timeoutMsg := `{"result_code":1,"result_msg":"login timeout","result_Data":{"service":"connect"}}`
+	svc.onMessage([]byte(timeoutMsg), nil)
+
+	// The ErrTimeout event must still be signalled so startWinetService reconnects.
+	select {
+	case event := <-svc.Events():
+		assert.ErrorIs(t, event.Err, ErrTimeout)
+	case <-time.After(time.Second):
+		t.Fatal("expected ErrTimeout on Events() channel within 1s")
+	}
+
+	// conn must still be non-nil — reconnect() was not called in-band.
+	svc.connMu.RLock()
+	currentConn := svc.conn
+	svc.connMu.RUnlock()
+	assert.Same(t, conn, currentConn, "conn must not be replaced by an in-band reconnect")
 }


### PR DESCRIPTION
Root cause: onMessage() called reconnect() in-band when a "login timeout"
was received, setting s.conn=nil while the poll-loop goroutine was
concurrently reading it in sendQueryRequest() (no nil check, no lock).

Fix:
- Remove the in-band reconnect() call from the login-timeout path in
  onMessage(). The SessionEvent{ErrTimeout} signal is sufficient;
  startWinetService will call Connect() which cancels the poll loop
  before calling reconnect(), eliminating the race window entirely.
- Add connMu sync.RWMutex + getConn() helper to guard all reads of
  s.conn against the remaining narrow window in the Connect() path
  (between cancelPoll() and the reconnect() write).
- Update reconnect() to hold the write lock around s.conn mutations
  and only publish the new connection after a successful Dial().
- Update runPollLoop, queryDevices, and sendQueryRequest to use getConn()
  so a nil conn is a clean early-return, not a panic.

Tests added:
- TestSendQueryRequest_NilConn_ReturnsError: nil conn → error, not panic
- TestSendQueryRequest_ConcurrentReconnect_DoesNotPanic: -race clean
- TestOnMessage_LoginTimeout_NoInBandReconnect: conn stays alive after
  timeout message; Close() is not called in-band

https://claude.ai/code/session_01QXVu9DR8CfsgHeT9Q4NSXd