### PR TITLE
Make MQTT publishing optional when MQTT_HOST is unset

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -97,17 +97,24 @@ func Run(ctx context.Context, cfg *config.Config) error {
 
 	defer cleanup()
 
-	mqttOpts := paho_mqtt.NewClientOptions()
-	mqttOpts.SetPassword(cfg.MqttCfg.Password)
-	mqttOpts.SetUsername(cfg.MqttCfg.Username)
-	mqttOpts.AddBroker(cfg.MqttCfg.Host)
+	publishers := []publisher.Publisher{db}
+	if cfg.MqttCfg.Host != "" {
+		mqttOpts := paho_mqtt.NewClientOptions()
+		mqttOpts.SetPassword(cfg.MqttCfg.Password)
+		mqttOpts.SetUsername(cfg.MqttCfg.Username)
+		mqttOpts.AddBroker(cfg.MqttCfg.Host)
 
-	mqttPublisher := mqtt.New(paho_mqtt.NewClient(mqttOpts))
-	if err := mqttPublisher.Connect(); err != nil {
-		return fmt.Errorf("failed to connect to MQTT broker: %w", err)
+		mqttPublisher := mqtt.New(paho_mqtt.NewClient(mqttOpts))
+		if err := mqttPublisher.Connect(); err != nil {
+			return fmt.Errorf("failed to connect to MQTT broker: %w", err)
+		}
+		publishers = append(publishers, mqttPublisher)
+		logger.Info("Connected to MQTT broker", zap.String("host", cfg.MqttCfg.Host))
+	} else {
+		logger.Info("MQTT_HOST not set; MQTT publishing disabled")
 	}
 
-	pub := publisher.NewMultiPublisher(db, mqttPublisher)
+	pub := publisher.NewMultiPublisher(publishers...)
 
 	authSvc := auth.NewService(cfg.AuthCfg.JWTSecret, cfg.AuthCfg.AccessTokenTTL, cfg.AuthCfg.RefreshTokenTTL, db, db)
 	authSvc.StartCleanup(ctx, time.Hour)

--- a/internal/pkg/config/config_test.go
+++ b/internal/pkg/config/config_test.go
@@ -91,6 +91,14 @@ func TestLoad_MissingDatabaseURL(t *testing.T) {
 	assert.Empty(t, cfg.DBDSN)
 }
 
+func TestLoad_WithoutMQTTHost(t *testing.T) {
+	setRequiredEnv(t)
+
+	cfg, err := Load()
+	require.NoError(t, err)
+	assert.Empty(t, cfg.MqttCfg.Host)
+}
+
 func TestLoad_CustomValues(t *testing.T) {
 	setRequiredEnv(t)
 	t.Setenv("LOG_LEVEL", "debug")


### PR DESCRIPTION
## Summary
- Skip MQTT broker connection and publishing when `MQTT_HOST` is not set
- Service continues with database-only publishing in that case
- Add config test confirming MQTT host is optional at startup

## Test plan
- [x] `go test ./cmd ./internal/pkg/config ./internal/pkg/publisher`
- [ ] Start service without `MQTT_HOST` and confirm it starts successfully
- [ ] Start service with `MQTT_HOST` set and confirm MQTT publishing still works


Made with [Cursor](https://cursor.com)